### PR TITLE
feat(home): hover-play video tiles for Mission & Programs (+ ignore .claude/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sln
 *.sw?
 .aider*
+
+# Local Claude Code state (worktrees, launch.json, session data)
+.claude/

--- a/src/app.css
+++ b/src/app.css
@@ -138,6 +138,46 @@
   }
 }
 
+/* Ken Burns-style hover pan/zoom — used by HoverPlayMedia tiles so the
+   poster image visibly moves on hover even when no looping video has been
+   wired up yet. The wrapping element should carry Tailwind's `group` class
+   so the animation triggers from anywhere on the card. */
+@keyframes hover-pan-zoom {
+  0% {
+    transform: scale(1) translate3d(0, 0, 0);
+    transform-origin: 50% 50%;
+  }
+  50% {
+    transform: scale(1.08) translate3d(-2%, -1.5%, 0);
+    transform-origin: 30% 40%;
+  }
+  100% {
+    transform: scale(1) translate3d(0, 0, 0);
+    transform-origin: 50% 50%;
+  }
+}
+
+.hover-pan-zoom {
+  transition: transform 0.45s ease-out;
+  will-change: transform;
+}
+
+.group:hover .hover-pan-zoom,
+.group:focus-within .hover-pan-zoom,
+.hover-pan-zoom:hover,
+.hover-pan-zoom:focus-visible {
+  animation: hover-pan-zoom 6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .group:hover .hover-pan-zoom,
+  .group:focus-within .hover-pan-zoom,
+  .hover-pan-zoom:hover,
+  .hover-pan-zoom:focus-visible {
+    animation: none;
+  }
+}
+
 .animate-spin-slow {
   animation: spin-slow 3s linear infinite;
 }

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -2,9 +2,13 @@ import React from "react";
 import Markdown from "markdown-to-jsx";
 import { Link } from "react-router-dom";
 import { ArrowRight } from "lucide-react"; // Import the icon
+import HoverPlayMedia from "./HoverPlayMedia";
 
 interface IndividualBlogProps {
   imageURL: string;
+  /** Optional path to a hover-play video. Falls back to the static image
+   *  when absent or unsupported. */
+  videoURL?: string;
   tag: string[];
   title: string;
   summary: string;
@@ -16,6 +20,7 @@ interface IndividualBlogProps {
 
 const IndividualBlog: React.FC<IndividualBlogProps> = ({
   imageURL,
+  videoURL,
   title,
   summary,
   link,
@@ -35,8 +40,9 @@ const IndividualBlog: React.FC<IndividualBlogProps> = ({
 
   const cardContent = (
     <div className={`${cardBaseClasses} ${cardLinkClasses}`}>
-      <img
-        src={imageURL}
+      <HoverPlayMedia
+        videoSrc={videoURL}
+        posterSrc={imageURL}
         alt={alt}
         width={width}
         height={height}
@@ -73,9 +79,10 @@ const IndividualBlog: React.FC<IndividualBlogProps> = ({
           {cardContent}
         </Link>
       ) : (
-        <div className="block h-full">
+        <div className="group block h-full">
           {" "}
-          {/* No group class needed here */}
+          {/* `group` so HoverPlayMedia can attach hover listeners; no
+              group-hover: styles target this branch */}
           {cardContent}
         </div>
       )}
@@ -90,6 +97,7 @@ export default function Blog() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <IndividualBlog
           imageURL="/pizza.webp"
+          videoURL="/pizza.mp4"
           tag={["community", "learning", "networking"]}
           title="Weekly General Body Meetings"
           summary="Join SoDA every week for our General Body Meetings on Tuesdays! We host workshops, tech talks, networking events, and more. It's a great way to learn, connect with fellow students, and get involved in the largest engineering organization at ASU. Free pizza included ;)"
@@ -100,6 +108,7 @@ export default function Blog() {
         />
         <IndividualBlog
           imageURL="/winner-winner-chicken-dinner.webp"
+          videoURL="/winner-winner-chicken-dinner.mp4"
           tag={["mentorship", "community development"]}
           title="Distinguished Members Program"
           summary="SoDA introduced points system designed to encourage active participation in our community. By attending meetings, events, and engaging in various activities, members can earn points that contribute to their standing within the organization. These points can be redeemed for exclusive rewards, recognition, and opportunities, fostering a vibrant and involved community."
@@ -110,6 +119,7 @@ export default function Blog() {
         />
         <IndividualBlog
           imageURL="/events/microsoft.webp"
+          videoURL="/events/microsoft.mp4"
           tag={["mentorship", "community development"]}
           title="Mentorship Program"
           summary="SoDA offers a comprehensive mentorship program designed to support those in need. Our program connects experienced mentors with mentees, providing guidance, and support to help them navigate their academic and professional journeys. "
@@ -125,8 +135,9 @@ export default function Blog() {
         className="group mt-6 w-full max-w-[1116px] block bg-neutral-900 border-gray-600 rounded-lg p-4 md:p-6 text-white overflow-hidden"
       >
         <div className="flex flex-col md:flex-row gap-5 md:gap-6 items-start md:items-center">
-          <img
-            src="/events/travel-reimbursement.png"
+          <HoverPlayMedia
+            videoSrc="/events/travel-reimbursement.mp4"
+            posterSrc="/events/travel-reimbursement.png"
             alt="Travel reimbursement form"
             width={5184}
             height={3456}

--- a/src/components/HoverPlayMedia.tsx
+++ b/src/components/HoverPlayMedia.tsx
@@ -26,8 +26,13 @@ interface HoverPlayMediaProps {
  *   muted, looping video.
  * - On leave/blur, pauses and resets the video to the first frame so the
  *   next hover starts cleanly.
- * - Respects `prefers-reduced-motion`: if the user prefers reduced motion
- *   the video never auto-plays — only the poster shows.
+ * - Adds a `hover-pan-zoom` class so a Ken Burns pan/zoom animation runs
+ *   on hover. This makes the tile feel alive even before per-card video
+ *   files exist, and stays in place once they do (CSS transform stacks on
+ *   the playing video element fine).
+ * - Respects `prefers-reduced-motion`: when the user prefers reduced motion
+ *   the video never auto-plays and the pan/zoom animation is disabled
+ *   (only the static poster shows).
  * - Falls back gracefully to the poster image when no `videoSrc` is provided
  *   (useful while video assets are still being produced).
  */
@@ -51,9 +56,14 @@ export default function HoverPlayMedia({
     return () => mq.removeEventListener("change", handler);
   }, []);
 
+  // Compose the hover animation class with whatever positioning/sizing
+  // classes the caller passes in. We always include `hover-pan-zoom` so the
+  // image moves on hover — the CSS rule itself bows out for reduced-motion.
+  const mediaClass = `${className} hover-pan-zoom`.trim();
+
   // If we have no video source or the user prefers reduced motion, just show
-  // the still poster — keeps the markup simple and avoids loading bytes we
-  // won't ever play.
+  // the still poster (the pan-zoom animation still runs unless reduced motion
+  // is set, in which case the CSS rule disables it for us).
   if (!videoSrc || reducedMotion) {
     return (
       <img
@@ -61,7 +71,7 @@ export default function HoverPlayMedia({
         alt={alt}
         width={width}
         height={height}
-        className={className}
+        className={mediaClass}
         loading="lazy"
       />
     );
@@ -70,8 +80,9 @@ export default function HoverPlayMedia({
   const play = () => {
     const v = videoRef.current;
     if (!v) return;
-    // play() returns a Promise that rejects if the browser blocks autoplay.
-    // Swallow the rejection — we just stay on the poster frame in that case.
+    // play() returns a Promise that rejects if the browser blocks autoplay
+    // or the source 404s. Swallow it — we just stay on the poster frame, and
+    // the CSS pan/zoom keeps the tile feeling alive.
     void v.play().catch(() => {});
   };
 
@@ -116,7 +127,7 @@ export default function HoverPlayMedia({
       aria-label={alt}
       width={width}
       height={height}
-      className={className}
+      className={mediaClass}
       onMouseEnter={play}
       onMouseLeave={pause}
       onFocus={play}

--- a/src/components/HoverPlayMedia.tsx
+++ b/src/components/HoverPlayMedia.tsx
@@ -48,6 +48,9 @@ export default function HoverPlayMedia({
   const videoRef = useRef<HTMLVideoElement>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
 
+  // Track the user's reduced-motion preference. Declared up here, before any
+  // conditional return below, so the hook order stays stable across renders
+  // (React Hooks rule #1).
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     setReducedMotion(mq.matches);
@@ -56,15 +59,52 @@ export default function HoverPlayMedia({
     return () => mq.removeEventListener("change", handler);
   }, []);
 
+  // If we have no video source, or the user prefers reduced motion, we'll
+  // render the still poster instead of the <video>. Compute the flag first
+  // so the effect below can use it as a dep and bail out when not needed.
+  const showFallback = !videoSrc || reducedMotion;
+
+  // The `group-hover:` / `group-focus:` pseudo-class equivalents can't be
+  // expressed declaratively for a `play()` call, so we attach listeners on
+  // the nearest `.group` ancestor at mount time when `playOnGroupHover` is
+  // on. We always declare the hook, but it's a no-op when we're falling
+  // back to the still image (no video to play).
+  useEffect(() => {
+    if (showFallback || !playOnGroupHover) return;
+    const v = videoRef.current;
+    if (!v) return;
+    const group = v.closest(".group") as HTMLElement | null;
+    if (!group) return;
+
+    const play = () => {
+      // play() returns a Promise that rejects if the browser blocks
+      // autoplay or the source 404s. Swallow it — we just stay on the
+      // poster frame, and the CSS pan/zoom keeps the tile feeling alive.
+      void v.play().catch(() => {});
+    };
+    const pause = () => {
+      v.pause();
+      v.currentTime = 0;
+    };
+
+    group.addEventListener("mouseenter", play);
+    group.addEventListener("mouseleave", pause);
+    group.addEventListener("focusin", play);
+    group.addEventListener("focusout", pause);
+    return () => {
+      group.removeEventListener("mouseenter", play);
+      group.removeEventListener("mouseleave", pause);
+      group.removeEventListener("focusin", play);
+      group.removeEventListener("focusout", pause);
+    };
+  }, [showFallback, playOnGroupHover]);
+
   // Compose the hover animation class with whatever positioning/sizing
   // classes the caller passes in. We always include `hover-pan-zoom` so the
   // image moves on hover — the CSS rule itself bows out for reduced-motion.
   const mediaClass = `${className} hover-pan-zoom`.trim();
 
-  // If we have no video source or the user prefers reduced motion, just show
-  // the still poster (the pan-zoom animation still runs unless reduced motion
-  // is set, in which case the CSS rule disables it for us).
-  if (!videoSrc || reducedMotion) {
+  if (showFallback) {
     return (
       <img
         src={posterSrc}
@@ -77,43 +117,21 @@ export default function HoverPlayMedia({
     );
   }
 
-  const play = () => {
+  // Direct-on-element handlers as a backup to the group-level listeners,
+  // so a hover that only crosses the media element (not the whole card)
+  // still plays. The closures intentionally read videoRef.current each
+  // call so they don't need to be in the effect's dep array.
+  const playOnElement = () => {
     const v = videoRef.current;
     if (!v) return;
-    // play() returns a Promise that rejects if the browser blocks autoplay
-    // or the source 404s. Swallow it — we just stay on the poster frame, and
-    // the CSS pan/zoom keeps the tile feeling alive.
     void v.play().catch(() => {});
   };
-
-  const pause = () => {
+  const pauseOnElement = () => {
     const v = videoRef.current;
     if (!v) return;
     v.pause();
     v.currentTime = 0;
   };
-
-  // The `group-hover:` / `group-focus:` pseudo-class equivalents can't be
-  // expressed declaratively for a `play()` call, so we attach listeners on
-  // the nearest `.group` ancestor at mount time when `playOnGroupHover` is on.
-  useEffect(() => {
-    if (!playOnGroupHover) return;
-    const v = videoRef.current;
-    if (!v) return;
-    const group = v.closest(".group") as HTMLElement | null;
-    if (!group) return;
-    group.addEventListener("mouseenter", play);
-    group.addEventListener("mouseleave", pause);
-    group.addEventListener("focusin", play);
-    group.addEventListener("focusout", pause);
-    return () => {
-      group.removeEventListener("mouseenter", play);
-      group.removeEventListener("mouseleave", pause);
-      group.removeEventListener("focusin", play);
-      group.removeEventListener("focusout", pause);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [playOnGroupHover, videoSrc]);
 
   return (
     <video
@@ -128,10 +146,10 @@ export default function HoverPlayMedia({
       width={width}
       height={height}
       className={mediaClass}
-      onMouseEnter={play}
-      onMouseLeave={pause}
-      onFocus={play}
-      onBlur={pause}
+      onMouseEnter={playOnElement}
+      onMouseLeave={pauseOnElement}
+      onFocus={playOnElement}
+      onBlur={pauseOnElement}
     />
   );
 }

--- a/src/components/HoverPlayMedia.tsx
+++ b/src/components/HoverPlayMedia.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react";
+
+interface HoverPlayMediaProps {
+  /** Path to a video file (mp4/webm). When omitted, the component renders the
+   *  poster image only — no <video> element is mounted and no hover behavior. */
+  videoSrc?: string;
+  /** Path to the still image shown when the video is paused (and as a fallback
+   *  if no video is provided). */
+  posterSrc: string;
+  alt: string;
+  className?: string;
+  width?: number;
+  height?: number;
+  /** When the parent has Tailwind's `group` class, the video will also start
+   *  playing on `group-hover` / `group-focus` of the parent, not just on
+   *  hover of the media element itself. Defaults to true. */
+  playOnGroupHover?: boolean;
+}
+
+/**
+ * YCombinator-style hover-play media tile.
+ *
+ * Behavior:
+ * - Renders the poster image initially.
+ * - On hover (or keyboard focus) of the parent group, starts playing the
+ *   muted, looping video.
+ * - On leave/blur, pauses and resets the video to the first frame so the
+ *   next hover starts cleanly.
+ * - Respects `prefers-reduced-motion`: if the user prefers reduced motion
+ *   the video never auto-plays — only the poster shows.
+ * - Falls back gracefully to the poster image when no `videoSrc` is provided
+ *   (useful while video assets are still being produced).
+ */
+export default function HoverPlayMedia({
+  videoSrc,
+  posterSrc,
+  alt,
+  className = "",
+  width,
+  height,
+  playOnGroupHover = true,
+}: HoverPlayMediaProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // If we have no video source or the user prefers reduced motion, just show
+  // the still poster — keeps the markup simple and avoids loading bytes we
+  // won't ever play.
+  if (!videoSrc || reducedMotion) {
+    return (
+      <img
+        src={posterSrc}
+        alt={alt}
+        width={width}
+        height={height}
+        className={className}
+        loading="lazy"
+      />
+    );
+  }
+
+  const play = () => {
+    const v = videoRef.current;
+    if (!v) return;
+    // play() returns a Promise that rejects if the browser blocks autoplay.
+    // Swallow the rejection — we just stay on the poster frame in that case.
+    void v.play().catch(() => {});
+  };
+
+  const pause = () => {
+    const v = videoRef.current;
+    if (!v) return;
+    v.pause();
+    v.currentTime = 0;
+  };
+
+  // The `group-hover:` / `group-focus:` pseudo-class equivalents can't be
+  // expressed declaratively for a `play()` call, so we attach listeners on
+  // the nearest `.group` ancestor at mount time when `playOnGroupHover` is on.
+  useEffect(() => {
+    if (!playOnGroupHover) return;
+    const v = videoRef.current;
+    if (!v) return;
+    const group = v.closest(".group") as HTMLElement | null;
+    if (!group) return;
+    group.addEventListener("mouseenter", play);
+    group.addEventListener("mouseleave", pause);
+    group.addEventListener("focusin", play);
+    group.addEventListener("focusout", pause);
+    return () => {
+      group.removeEventListener("mouseenter", play);
+      group.removeEventListener("mouseleave", pause);
+      group.removeEventListener("focusin", play);
+      group.removeEventListener("focusout", pause);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playOnGroupHover, videoSrc]);
+
+  return (
+    <video
+      ref={videoRef}
+      src={videoSrc}
+      poster={posterSrc}
+      muted
+      loop
+      playsInline
+      preload="none"
+      aria-label={alt}
+      width={width}
+      height={height}
+      className={className}
+      onMouseEnter={play}
+      onMouseLeave={pause}
+      onFocus={play}
+      onBlur={pause}
+    />
+  );
+}

--- a/src/components/Mission.tsx
+++ b/src/components/Mission.tsx
@@ -1,9 +1,12 @@
+import HoverPlayMedia from "./HoverPlayMedia";
+
 const perks = [
   {
     header: "Professional Development",
     description:
       "SoDA offers boundless opportunities to advance your career. From technical workshops hosted by industry leaders to career fairs and networking events, you’ll gain invaluable experience and connections to kickstart your journey as a software developer.",
     imgURL: "/events/amazon-table.webp",
+    videoURL: "/events/amazon-table.mp4",
     alt: "Amazon table at a SoDA event",
   },
   {
@@ -11,6 +14,7 @@ const perks = [
     description:
       "SoDA provides a supportive network of fellow computer science students, offering collaboration, encouragement, and a sense of belonging through regular meetings and events with free food.",
     imgURL: "/events/microsoft-resume-review.webp",
+    videoURL: "/events/microsoft-resume-review.mp4",
     alt: "Microsoft resume review at a SoDA event",
   },
   {
@@ -18,6 +22,7 @@ const perks = [
     description:
       "Enhance your skills through a variety of learning opportunities, including coding workshops, bootcamps, and talks from industry professionals. SoDA is committed to your personal and professional growth, ensuring you stay ahead in the fast-paced tech world.",
     imgURL: "/events/what-is-soda.webp",
+    videoURL: "/events/what-is-soda.mp4",
     alt: "SoDA members at a meeting",
   },
 ];
@@ -31,12 +36,13 @@ export default function Mission() {
           {perks.map((perk) => (
             <div
               key={perk.header}
-              className="bg-neutral-900  p-4 border-gray-600 rounded-2xl justify-center flex flex-col min-h-[300px] max-w-[300px] w-full"
+              className="group bg-neutral-900  p-4 border-gray-600 rounded-2xl justify-center flex flex-col min-h-[300px] max-w-[300px] w-full"
             >
-              <img
-                src={perk.imgURL}
-                className="rounded-t-xl object-cover w-full h-48"
+              <HoverPlayMedia
+                videoSrc={perk.videoURL}
+                posterSrc={perk.imgURL}
                 alt={perk.alt}
+                className="rounded-t-xl object-cover w-full h-48"
               />
               <div className="text-white px-4 py-3 space-y-3 text-left flex-1">
                 <h4 className="font-semibold text-xl max-md:text-lg">{perk.header}</h4>

--- a/src/components/Mission.tsx
+++ b/src/components/Mission.tsx
@@ -36,7 +36,7 @@ export default function Mission() {
           {perks.map((perk) => (
             <div
               key={perk.header}
-              className="group bg-neutral-900  p-4 border-gray-600 rounded-2xl justify-center flex flex-col min-h-[300px] max-w-[300px] w-full"
+              className="group bg-neutral-900  p-4 border-gray-600 rounded-2xl overflow-hidden justify-center flex flex-col min-h-[300px] max-w-[300px] w-full"
             >
               <HoverPlayMedia
                 videoSrc={perk.videoURL}


### PR DESCRIPTION
## Summary
- New reusable `HoverPlayMedia` component renders a muted, looping video that plays on hover or keyboard focus and rewinds on leave 
- Wired into all 3 Mission pillar cards and all 4 Programs cards (including the wide Travel Reimbursement tile).
- Adds a **pan-and-zoom animation to the poster so it visibly moves on hover**, until real videos are wired up. 
- Bundles the previously-staged `chore: ignore local .claude/` commit so this PR also lands the gitignore rule for Claude Code's local-only state.

## Why
Short looping clips give the page motion without auto-playing on load. And because real per-card videos haven't been produced yet, the poster image needed its own motion treatment so the tiles don't look broken in the meantime — hence the CSS pan/zoom fallback.

## Implementation
- **`src/components/HoverPlayMedia.tsx`**
  - Renders `<img>` only when no `videoSrc` is provided, or when the user has `prefers-reduced-motion: reduce`.
  - Otherwise renders `<video muted loop playsInline preload="none">` with the image as `poster`, so the still frame shows until the video data is fetched.
  - Always appends a `hover-pan-zoom` class to whichever element it renders so the CSS pan/zoom animation kicks in on hover/focus.
  - Hover/focus listeners are attached to both the media element and (by default) the nearest `.group` ancestor, so hovering anywhere on the card triggers play.
  - `play()` rejections are swallowed silently — if a video file 404s, the user just keeps seeing the (now-animated) poster.
- **`src/app.css`**
  - New `@keyframes hover-pan-zoom` (gentle scale 1 → 1.08 + offset translate + transform-origin shift).
  - `.group:hover .hover-pan-zoom`, `.group:focus-within .hover-pan-zoom`, `.hover-pan-zoom:hover`, and `.hover-pan-zoom:focus-visible` all activate the animation.
  - `@media (prefers-reduced-motion: reduce)` disables the animation entirely.
- **`Mission.tsx`** and **`Blog.tsx`** (Programs): each card gets a `videoURL` paired with the existing poster image. The Mission card containers also gain `overflow-hidden` so the zoomed poster stays clipped inside the `rounded-2xl` corners. The no-link Weekly GBM card wrapper picks up `group` so hover-play works there too.
- **`.gitignore`**: `.claude/` added so Claude Code's local-only state (worktrees, launch.json, session data) cannot be accidentally committed via `git add .` or `git add -A`.

## Reviewer notes
- Video files at the referenced paths (`/events/amazon-table.mp4`, `/pizza.mp4`, etc.) **do not exist yet**. The page intentionally still ships cleanly without them — the poster image stays visible (and animates on hover) if the video request fails. Drop `.mp4`/`.webm` files at those paths to activate playback per card.
- Recommended encode: H.264, ~1080p, 5–10 s loop, ≤ 2 MB.

## Test plan
- [ ] Visit `/` — Mission and Programs cards show their poster images as before; no console errors with video files missing
- [ ] Hover a Mission or Programs tile — poster pans and zooms slowly, returns smoothly on leave
- [ ] Keyboard-tab through Programs links — pan/zoom animation triggers on focus
- [ ] When a real `.mp4` is added at a referenced path, hover plays the video; leaving pauses and rewinds
- [ ] Toggle OS "Reduce motion" — hovering shows the still poster only, no pan/zoom and no video playback
- [ ] `git check-ignore -v .claude` matches the new gitignore rule
- [ ] `git status` no longer lists `.claude/` as untracked

<img width="1203" height="674" alt="image" src="https://github.com/user-attachments/assets/4b5a2ec0-4f75-472f-bbcc-1ffbcc05fa6f" />
